### PR TITLE
Fixed get_document_or_404 for mongoengine>=0.10

### DIFF
--- a/documentation/docs/generics.md
+++ b/documentation/docs/generics.md
@@ -16,6 +16,6 @@ and use drfme_generics.ListAPIView, drfme_generics.ListCreateAPIView and so on.
 
 ## Overriding get_object()
 
-When overriding `get_object()`, remember to user `get_document_or_404()` instead of `get_object_or_404()`
+Since Django `get_object_or_404()` shortcut catches only Django ORM DoesNotExist exception and mongoengine has similar, but separatec exceptions, we should replace `get_object_or_404()` usage with try..catch block.
 
-`from mongoengine.django.shortcuts import get_document_or_404`
+For history purposes: there was `get_document_or_404` shortcut. But since 0.10 mongoengine has dropped Django helpers support.

--- a/rest_framework_mongoengine/generics.py
+++ b/rest_framework_mongoengine/generics.py
@@ -1,7 +1,6 @@
 from rest_framework import mixins
 from rest_framework import generics as drf_generics
 
-from mongoengine.django.shortcuts import get_document_or_404
 from mongoengine.queryset.base import BaseQuerySet
 
 
@@ -24,7 +23,7 @@ class GenericAPIView(drf_generics.GenericAPIView):
 
     def get_object(self):
         """
-        *** Inherited from DRF 3 GenericAPIView, swapped get_object_or_404() with get_document_or_404() ***
+        *** Inherited from DRF 3 GenericAPIView, swapped get_object_or_404() with similar logic for mongoengine ***
 
         Returns the object the view is displaying.
 
@@ -45,7 +44,12 @@ class GenericAPIView(drf_generics.GenericAPIView):
         )
 
         filter_kwargs = {self.lookup_field: self.kwargs[lookup_url_kwarg]}
-        obj = get_document_or_404(queryset, **filter_kwargs)
+
+        try:
+            obj = queryset.get(**filter_kwargs)
+        except (queryset._document.DoesNotExist, ValidationError):
+            from django.http import Http404
+            raise Http404('No %s matches the given query.' % queryset._document._class_name)
 
         # May raise a permission denied
         self.check_object_permissions(self.request, obj)


### PR DESCRIPTION
Since 0.10 mongoengine has dropped Django stuff, so we should work it around. It is easy since we use just one simple shourtcut, should be good enough.
